### PR TITLE
Adjusted projects display on various browsers

### DIFF
--- a/src/components/Homepage/ProjectsTabs/ProjectsTabs.jsx
+++ b/src/components/Homepage/ProjectsTabs/ProjectsTabs.jsx
@@ -75,7 +75,7 @@ const ProjectsTabs = ({ projectsApiElements, latestProjectsHeader }) => {
                 <ProjectDescription>{description}</ProjectDescription>
                 {linkUrl && (
                   <ButtonWrapper>
-                    <a href={linkUrl} target="_blank" rel="noreferrer">
+                    <a href={linkUrl}>
                       <SmallButton icon={linkUrl.includes('facebook')}>
                         {linkUrl.includes('facebook') && <FacebookIcon />}
                         {linkCaption}

--- a/src/components/Subpages/AboutUs/ManagementSection/ManagementSection.jsx
+++ b/src/components/Subpages/AboutUs/ManagementSection/ManagementSection.jsx
@@ -1,5 +1,6 @@
 import PropTypes, { oneOfType } from 'prop-types';
 import { documentToReactComponents } from '@contentful/rich-text-react-renderer';
+import compareProjectsOrder from '@root/handlers/compareProjectsOrder';
 import MemberTile from './MemberTile';
 import {
   SectionWrapper,
@@ -10,6 +11,7 @@ import {
 } from './ManagementSection.styles';
 
 const ManagementSection = ({ boardMembers, boardMembersText }) => {
+  const sortedBoardMembers = [...boardMembers].sort(compareProjectsOrder);
   const sectionTitle = boardMembersText.title;
   const sectionDescription = documentToReactComponents(boardMembersText.text1);
   return (
@@ -19,7 +21,7 @@ const ManagementSection = ({ boardMembers, boardMembersText }) => {
         <StyledBodyText>{sectionDescription}</StyledBodyText>
       </TextSection>
       <TilesWrapper>
-        {boardMembers.map((member) => (
+        {sortedBoardMembers.map((member) => (
           <MemberTile key={member.fields.name} memberInfo={member.fields} />
         ))}
       </TilesWrapper>

--- a/src/components/Subpages/Projects/Tabs/ProjectTile.jsx
+++ b/src/components/Subpages/Projects/Tabs/ProjectTile.jsx
@@ -28,10 +28,10 @@ const ProjectTile = ({ projectData }) => {
         <ProjectDescription>{description}</ProjectDescription>
         {linkUrl && (
           <ButtonWrapper>
-            <a href={linkUrl} target="_blank" rel="noreferrer">
+            <a href={linkUrl}>
               <SmallButton icon={linkContainsFacebook}>
                 {linkContainsFacebook && <FacebookIcon />}
-                {linkCaption}
+                {linkCaption || 'Przejdź do wydarzenia'}
               </SmallButton>
             </a>
           </ButtonWrapper>

--- a/src/components/Subpages/Projects/Tabs/Tabs.jsx
+++ b/src/components/Subpages/Projects/Tabs/Tabs.jsx
@@ -42,14 +42,14 @@ const Tabs = ({ projectsList, middleCta }) => {
       {uniqueProjectsYears.map((year) => (
         <>
           <StyledTabPanel>
-            <FirstProjectsSection>
+            <FirstProjectsSection oneProject={projectsByYear[year].length === 1}>
               {projectsByYear[year].slice(0, 4).map((project) => (
                 <ProjectTile projectData={project} />
               ))}
             </FirstProjectsSection>
 
             {projectsByYear[year].length >= 3 && <Cta middleCta={middleCta} />}
-            <SecondProjectsSection>
+            <SecondProjectsSection oneProject={projectsByYear[year].length === 5}>
               {projectsByYear[year].slice(4).map((project) => (
                 <ProjectTile projectData={project} />
               ))}

--- a/src/components/Subpages/Projects/Tabs/Tabs.styles.js
+++ b/src/components/Subpages/Projects/Tabs/Tabs.styles.js
@@ -161,6 +161,7 @@ export const ProjectWrapper = styled.div`
   break-inside: avoid;
   transform: translateZ(0);
   margin-bottom: 24px;
+
   @media ${({ theme }) => theme.medias.medium} {
     &:nth-child(4) {
       margin-bottom: 0;
@@ -195,12 +196,14 @@ export const StyledCtaText = styled(H3)`
 `;
 
 export const FirstProjectsSection = styled.div`
-  column-count: 2;
+  column-count: ${({ oneProject }) => (oneProject ? 'auto' : '2')};
+  display: ${({ oneProject }) => (oneProject ? 'flex' : 'block')};
   column-gap: 24px;
-  width: 100%;
+  width: ${({ oneProject }) => (oneProject ? '50%' : '100%')};
 
   @media ${({ theme }) => theme.medias.medium} {
     column-count: 1;
+    width: 100%;
   }
 `;
 


### PR DESCRIPTION
Fixed projects tabs display on projects subpage on browsers other than chrome
*hotfix - added sorting board members by order
*hotfix - added default link caption for project tab button when linkUrl is provided without linkCaption defined in API